### PR TITLE
Improve the JSONResponse performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/savsgio/atreugo
 
 require (
 	github.com/fasthttp/router v0.2.0
+	github.com/json-iterator/go v1.1.5
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/savsgio/go-logger v0.0.0-20181102112400-e6a7c74978c0
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/valyala/fasthttp v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,15 @@
 github.com/fasthttp/router v0.2.0 h1:1k4jLGRwDTPq1QbIYVa5+zJxWixWCWYxgOG5mwbpRvA=
 github.com/fasthttp/router v0.2.0/go.mod h1:ENXeGFIg8mQS+sUPNQ/DboXat7SpQMKlDKMpKgE39pc=
+github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
+github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/klauspost/compress v1.4.0 h1:8nsMz3tWa9SWWPL60G1V6CUsf4lLjWLTNEtibhe8gh8=
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e h1:+lIPJOWl+jSiJOc70QXJ07+2eg2Jy2EC7Mi11BWujeM=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
+github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/savsgio/go-logger v0.0.0-20181102112400-e6a7c74978c0 h1:BnYHq7EjtqUp3Z0utOF526x/b+FZErMzgH9FIB0BbGk=
 github.com/savsgio/go-logger v0.0.0-20181102112400-e6a7c74978c0/go.mod h1:/ZzTTmB3JJqjZQcLlxTGbwy3fIsLUoYyldsSEL5rU2g=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/response.go
+++ b/response.go
@@ -1,8 +1,7 @@
 package atreugo
 
 import (
-	"encoding/json"
-
+	jsoniter "github.com/json-iterator/go"
 	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp"
 )
@@ -23,7 +22,13 @@ func (ctx *RequestCtx) newResponse(contentType string, statusCode ...int) {
 func (ctx *RequestCtx) JSONResponse(body interface{}, statusCode ...int) error {
 	ctx.newResponse("application/json", statusCode...)
 
-	return json.NewEncoder(ctx).Encode(body)
+	data, err := jsoniter.Marshal(body)
+	if err != nil {
+		return err
+	}
+	ctx.Write(data)
+
+	return nil
 }
 
 // HTTPResponse return response with body in html format

--- a/response_test.go
+++ b/response_test.go
@@ -596,13 +596,13 @@ func Benchmark_FileResponse(b *testing.B) {
 	}
 }
 
-func BenchmarkJsoniter_JSONResponse(b *testing.B) {
+func Benchmark_JSONResponse(b *testing.B) {
 	ctx := new(fasthttp.RequestCtx)
 	actx := acquireRequestCtx(ctx)
 
 	body := JSON{
 		"hello":  11,
-		"friend": "ascas6d34534rtf3q·$·$&·$&$&&$/%&(XCCVasdfasgfds",
+		"friend": "ascas6d34534rtf3q·$·$&·$&$&&$/&(XCCVasdfasgfds",
 		"jsonData": JSON{
 			"111": 24.3,
 			"asdasdasd23423end3in32im13dfc23fc2 fcec2c": ctx,

--- a/response_test.go
+++ b/response_test.go
@@ -77,6 +77,7 @@ func TestJSONResponse(t *testing.T) {
 		body        string
 		statusCode  int
 		contentType string
+		err         bool
 	}
 	tests := []struct {
 		name string
@@ -84,7 +85,7 @@ func TestJSONResponse(t *testing.T) {
 		want want
 	}{
 		{
-			name: "Test",
+			name: "ValidBody",
 			args: args{
 				body:       JSON{"test": true},
 				statusCode: 200,
@@ -93,6 +94,20 @@ func TestJSONResponse(t *testing.T) {
 				body:        "{\"test\":true}",
 				statusCode:  200,
 				contentType: "application/json",
+				err:         false,
+			},
+		},
+		{
+			name: "InvalidBody",
+			args: args{
+				body:       make(chan int),
+				statusCode: 200,
+			},
+			want: want{
+				body:        "",
+				statusCode:  200,
+				contentType: "application/json",
+				err:         true,
 			},
 		},
 	}
@@ -102,8 +117,9 @@ func TestJSONResponse(t *testing.T) {
 			ctx := new(fasthttp.RequestCtx)
 			actx := acquireRequestCtx(ctx)
 
-			if err := actx.JSONResponse(tt.args.body, tt.args.statusCode); err != nil {
-				t.Errorf("JSONResponse() error: %v", err)
+			err := actx.JSONResponse(tt.args.body, tt.args.statusCode)
+			if tt.want.err && (err == nil) {
+				t.Errorf("JSONResponse() Expected error")
 			}
 
 			responseBody := string(bytes.TrimSpace(actx.Response.Body()))

--- a/response_test.go
+++ b/response_test.go
@@ -602,7 +602,7 @@ func BenchmarkJsoniter_JSONResponse(b *testing.B) {
 
 	body := JSON{
 		"hello":  11,
-		"friend": "ascas6d34534rtf3q·$·$%&·$%&$&&$/%&(XCCVasdfasgfds",
+		"friend": "ascas6d34534rtf3q·$·$&·$&$&&$/%&(XCCVasdfasgfds",
 		"jsonData": JSON{
 			"111": 24.3,
 			"asdasdasd23423end3in32im13dfc23fc2 fcec2c": ctx,

--- a/response_test.go
+++ b/response_test.go
@@ -595,3 +595,22 @@ func Benchmark_FileResponse(b *testing.B) {
 		actx.FileResponse("hola", path, "text/plain")
 	}
 }
+
+func BenchmarkJsoniter_JSONResponse(b *testing.B) {
+	ctx := new(fasthttp.RequestCtx)
+	actx := acquireRequestCtx(ctx)
+
+	body := JSON{
+		"hello":  11,
+		"friend": "ascas6d34534rtf3q·$·$%&·$%&$&&$/%&(XCCVasdfasgfds",
+		"jsonData": JSON{
+			"111": 24.3,
+			"asdasdasd23423end3in32im13dfc23fc2 fcec2c": ctx,
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i <= b.N; i++ {
+		actx.JSONResponse(body)
+	}
+}


### PR DESCRIPTION
- Use github.com/json-iterator/go instead encoding/json to reduce extra allocations