### PR TITLE
A "Before" middleware can stop the execution chain

### DIFF
--- a/examples/jwt_auth/middlewares.go
+++ b/examples/jwt_auth/middlewares.go
@@ -26,5 +26,5 @@ func authMiddleware(ctx *atreugo.RequestCtx) (int, error) {
 		return fasthttp.StatusForbidden, errors.New("your session is expired, login again please")
 	}
 
-	return fasthttp.StatusOK, err
+	return 0, err
 }

--- a/examples/middlewares_filters/filters.go
+++ b/examples/middlewares_filters/filters.go
@@ -8,11 +8,11 @@ import (
 func beforeFilter(ctx *atreugo.RequestCtx) (int, error) {
 	logger.Info("Filter executed BEFORE view")
 
-	return 200, nil
+	return 0, nil
 }
 
 func afterFilter(ctx *atreugo.RequestCtx) (int, error) {
 	logger.Info("Filter executed AFTER view")
 
-	return 200, nil
+	return 0, nil
 }

--- a/examples/middlewares_filters/middlewares.go
+++ b/examples/middlewares_filters/middlewares.go
@@ -8,11 +8,11 @@ import (
 func beforeMiddleware(ctx *atreugo.RequestCtx) (int, error) {
 	logger.Info("Middleware executed BEFORE view")
 
-	return 200, nil
+	return 0, nil
 }
 
 func afterMiddleware(ctx *atreugo.RequestCtx) (int, error) {
 	logger.Info("Middleware executed AFTER view")
 
-	return 200, nil
+	return 0, nil
 }

--- a/examples/static_files/filters.go
+++ b/examples/static_files/filters.go
@@ -8,11 +8,11 @@ import (
 func beforeFilter(ctx *atreugo.RequestCtx) (int, error) {
 	logger.Info("Filter executed BEFORE view")
 
-	return 200, nil
+	return 0, nil
 }
 
 func afterFilter(ctx *atreugo.RequestCtx) (int, error) {
 	logger.Info("Filter executed AFTER view")
 
-	return 200, nil
+	return 0, nil
 }

--- a/examples/static_files/middlewares.go
+++ b/examples/static_files/middlewares.go
@@ -8,11 +8,11 @@ import (
 func beforeMiddleware(ctx *atreugo.RequestCtx) (int, error) {
 	logger.Info("Middleware executed BEFORE view")
 
-	return 200, nil
+	return 0, nil
 }
 
 func afterMiddleware(ctx *atreugo.RequestCtx) (int, error) {
 	logger.Info("Middleware executed AFTER view")
 
-	return 200, nil
+	return 0, nil
 }

--- a/middlewares/request_id.go
+++ b/middlewares/request_id.go
@@ -3,7 +3,6 @@ package middlewares
 import (
 	"github.com/google/uuid"
 	"github.com/savsgio/atreugo/v8"
-	"github.com/valyala/fasthttp"
 )
 
 // RequestIDMiddleware adds an identifier to the request
@@ -16,5 +15,5 @@ func RequestIDMiddleware(ctx *atreugo.RequestCtx) (int, error) {
 		ctx.Request.Header.Set(atreugo.XRequestIDHeader, uuid.New().String())
 	}
 
-	return fasthttp.StatusOK, nil
+	return 0, nil
 }

--- a/middlewares/request_id_test.go
+++ b/middlewares/request_id_test.go
@@ -55,8 +55,8 @@ func TestRequestIDMiddleware(t *testing.T) {
 				return
 			}
 
-			if statusCode != fasthttp.StatusOK {
-				t.Errorf("RequestIDMiddleware() = %v, want %v", statusCode, fasthttp.StatusOK)
+			if statusCode != 0 {
+				t.Errorf("RequestIDMiddleware() = %v, want %v", statusCode, 0)
 			}
 
 			value := ctx.Request.Header.Peek(atreugo.XRequestIDHeader)

--- a/utils.go
+++ b/utils.go
@@ -22,12 +22,12 @@ func include(vs []string, t string) bool {
 // execMiddlewares execute all the middlewares functions with the request context given
 func execMiddlewares(ctx *RequestCtx, middlewares []Middleware) (int, error) {
 	for _, middlewareFn := range middlewares {
-		if statusCode, err := middlewareFn(ctx); err != nil {
+		if statusCode, err := middlewareFn(ctx); statusCode != 0 || err != nil {
 			return statusCode, err
 		}
 	}
 
-	return fasthttp.StatusOK, nil
+	return 0, nil
 }
 
 func viewToHandler(view View) fasthttp.RequestHandler {


### PR DESCRIPTION
It breaks API compatibility, but makes it more consistent, IMHO.