### PR TITLE
Lints: minimal set of fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+linters:
+  enable:
+    - megacheck
+    - govet
+    - errcheck
+    - unused
+    - structcheck
+  disable-all: false
+  fast: false
+
+

--- a/atreugo_test.go
+++ b/atreugo_test.go
@@ -478,7 +478,9 @@ func TestAtreugo_ListenAndServe(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 			case <-time.After(200 * time.Millisecond):
-				s.server.Shutdown()
+				if err := s.server.Shutdown(); err != nil {
+					t.Errorf("Error shutting down the server %+v", err)
+				}
 				if tt.want.getErr {
 					t.Error("Error expected")
 				}

--- a/atreugo_test.go
+++ b/atreugo_test.go
@@ -3,7 +3,6 @@ package atreugo
 import (
 	"bytes"
 	"errors"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -14,11 +13,6 @@ import (
 
 var testAtreugoConfig = &Config{
 	LogLevel: "fatal",
-}
-
-var random = func(min, max int) int {
-	rand.Seed(time.Now().Unix())
-	return rand.Intn(max-min) + min
 }
 
 func Test_New(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -31,7 +31,9 @@ func Test_releaseRequestCtx(t *testing.T) {
 func TestRequestCtx_reset(t *testing.T) {
 	ctx := new(fasthttp.RequestCtx)
 	actx := acquireRequestCtx(ctx)
-	actx.Next()
+	if err := actx.Next(); err != nil {
+		t.Fatalf("Error calling next. %+v", err)
+	}
 	actx.SkipView()
 
 	actx.reset()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/savsgio/atreugo/v10
 go 1.13
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fasthttp/router v0.5.5
 	github.com/google/uuid v1.1.1
 	github.com/json-iterator/go v1.1.9

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/savsgio/atreugo/v10
 go 1.13
 
 require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fasthttp/router v0.5.5
 	github.com/google/uuid v1.1.1
 	github.com/json-iterator/go v1.1.9

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/fasthttp/router v0.5.5 h1:40mVG2hmI+SkWHQR/Ns2wwY/YOU6BxVUB5DdzYolAzQ=
 github.com/fasthttp/router v0.5.5/go.mod h1:ok2CW5WiRNRXmjfMSutqWVFT7oy187T1SYTPCdp48V0=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -17,12 +16,14 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OH
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/savsgio/go-logger v1.0.0 h1:jiaRvohRr8RwtcK/WDcA/Yp4eaPaarAko3JNPzt1xoQ=
 github.com/savsgio/go-logger v1.0.0/go.mod h1:/ZzTTmB3JJqjZQcLlxTGbwy3fIsLUoYyldsSEL5rU2g=
 github.com/savsgio/gotils v0.0.0-20190925070755-524bc4f47500 h1:9Pi10H7E8E79/x2HSe1FmMGd7BJ1WAqDKzwjpv+ojFg=
 github.com/savsgio/gotils v0.0.0-20190925070755-524bc4f47500/go.mod h1:lHhJedqxCoHN+zMtwGNTXWmF0u9Jt363FYRhV6g0CdY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,11 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/fasthttp/router v0.5.5 h1:40mVG2hmI+SkWHQR/Ns2wwY/YOU6BxVUB5DdzYolAzQ=
 github.com/fasthttp/router v0.5.5/go.mod h1:ok2CW5WiRNRXmjfMSutqWVFT7oy187T1SYTPCdp48V0=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/response.go
+++ b/response.go
@@ -83,7 +83,9 @@ func (ctx *RequestCtx) FileResponse(fileName, filePath, mimeType string) error {
 
 	buff := bytebufferpool.Get()
 	buff.SetString("attachment; filename=")
-	buff.WriteString(fileName)
+	if _, err := buff.WriteString(fileName); err != nil {
+		return err
+	}
 
 	ctx.Response.Header.Set("Content-Disposition", buff.String())
 	ctx.SetContentType(mimeType)

--- a/response.go
+++ b/response.go
@@ -83,9 +83,7 @@ func (ctx *RequestCtx) FileResponse(fileName, filePath, mimeType string) error {
 
 	buff := bytebufferpool.Get()
 	buff.SetString("attachment; filename=")
-	if _, err := buff.WriteString(fileName); err != nil {
-		return err
-	}
+	buff.WriteString(fileName) // nolint:errcheck
 
 	ctx.Response.Header.Set("Content-Disposition", buff.String())
 	ctx.SetContentType(mimeType)

--- a/response_test.go
+++ b/response_test.go
@@ -520,13 +520,17 @@ func TestFileResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ioutil.WriteFile(tt.args.filePath, testFileContent, 0644)
+			if err := ioutil.WriteFile(tt.args.filePath, testFileContent, 0644); err != nil {
+				t.Fatalf("Error writing file %s", tt.args.filePath)
+			}
 			defer os.Remove(tt.args.filePath)
 
 			ctx := new(fasthttp.RequestCtx)
 			actx := acquireRequestCtx(ctx)
 
-			actx.FileResponse(tt.args.fileName, tt.args.filePath, tt.args.mimeType)
+			if err := actx.FileResponse(tt.args.fileName, tt.args.filePath, tt.args.mimeType); err != nil {
+				t.Fatalf("Error creating FileResponse for %s", tt.args.fileName)
+			}
 
 			responseBody := string(bytes.TrimSpace(actx.Response.Body()))
 			if responseBody != tt.want.body {
@@ -660,7 +664,9 @@ func Benchmark_FileResponse(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i <= b.N; i++ {
-		actx.FileResponse("hola", path, "text/plain")
+		if err := actx.FileResponse("hola", path, "text/plain"); err != nil {
+			b.Fatalf("Error calling FileResponse. %+v", err)
+		}
 	}
 }
 
@@ -679,6 +685,8 @@ func Benchmark_JSONResponse(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i <= b.N; i++ {
-		actx.JSONResponse(body)
+		if err := actx.JSONResponse(body); err != nil {
+			b.Fatalf("Error calling JSONResponse. %+v", err)
+		}
 	}
 }

--- a/response_test.go
+++ b/response_test.go
@@ -70,9 +70,8 @@ func Test_newResponse(t *testing.T) {
 
 func TestJSONResponse(t *testing.T) {
 	type args struct {
-		body        interface{}
-		statusCode  int
-		contentType string
+		body       interface{}
+		statusCode int
 	}
 	type want struct {
 		body        string
@@ -143,9 +142,8 @@ func TestJSONResponse(t *testing.T) {
 
 func TestHTTPResponse(t *testing.T) {
 	type args struct {
-		body        string
-		statusCode  int
-		contentType string
+		body       string
+		statusCode int
 	}
 	type want struct {
 		body        string
@@ -200,9 +198,8 @@ func TestHTTPResponse(t *testing.T) {
 
 func TestHTTPResponseBytes(t *testing.T) {
 	type args struct {
-		body        []byte
-		statusCode  int
-		contentType string
+		body       []byte
+		statusCode int
 	}
 	type want struct {
 		body        string
@@ -257,9 +254,8 @@ func TestHTTPResponseBytes(t *testing.T) {
 
 func TestTextResponse(t *testing.T) {
 	type args struct {
-		body        string
-		statusCode  int
-		contentType string
+		body       string
+		statusCode int
 	}
 	type want struct {
 		body        string
@@ -314,9 +310,8 @@ func TestTextResponse(t *testing.T) {
 
 func TestTextResponseBytes(t *testing.T) {
 	type args struct {
-		body        []byte
-		statusCode  int
-		contentType string
+		body       []byte
+		statusCode int
 	}
 	type want struct {
 		body        string
@@ -371,9 +366,8 @@ func TestTextResponseBytes(t *testing.T) {
 
 func TestRawResponse(t *testing.T) {
 	type args struct {
-		body        string
-		statusCode  int
-		contentType string
+		body       string
+		statusCode int
 	}
 	type want struct {
 		body        string
@@ -428,9 +422,8 @@ func TestRawResponse(t *testing.T) {
 
 func TestRawResponseBytes(t *testing.T) {
 	type args struct {
-		body        []byte
-		statusCode  int
-		contentType string
+		body       []byte
+		statusCode int
 	}
 	type want struct {
 		body        string

--- a/router_test.go
+++ b/router_test.go
@@ -514,7 +514,9 @@ func TestRouter_Path(t *testing.T) {
 		getPanic bool
 	}
 	testViewFn := func(ctx *RequestCtx) error {
-		ctx.WriteString("Test")
+		if _, err := ctx.WriteString("Test"); err != nil {
+			t.Fatalf("Error calling WriteString. %+v", err)
+		}
 		return nil
 	}
 
@@ -525,7 +527,9 @@ func TestRouter_Path(t *testing.T) {
 	testMuxHandler.HandleFunc("/", testNetHTTPHandler)
 
 	testHandler := func(ctx *fasthttp.RequestCtx) {
-		ctx.WriteString("Test")
+		if _, err := ctx.WriteString("Test"); err != nil {
+			t.Fatalf("Error in WriteString. %+v", err)
+		}
 	}
 
 	tests := []struct {

--- a/types.go
+++ b/types.go
@@ -15,7 +15,7 @@ import (
 //
 // It is prohibited copying Atreugo values. Create new values instead.
 type Atreugo struct {
-	noCopy nocopy.NoCopy
+	noCopy nocopy.NoCopy // nolint:structcheck,unused
 
 	server *fasthttp.Server
 	log    *logger.Logger
@@ -29,7 +29,7 @@ type Atreugo struct {
 //
 // It is prohibited copying Router values. Create new values instead.
 type Router struct {
-	noCopy nocopy.NoCopy
+	noCopy nocopy.NoCopy // nolint:structcheck,unused
 
 	router *fastrouter.Router
 	log    *logger.Logger
@@ -277,7 +277,7 @@ type Config struct {
 //
 // It is prohibited copying StaticFS values. Create new values instead.
 type StaticFS struct {
-	noCopy nocopy.NoCopy
+	noCopy nocopy.NoCopy // nolint:structcheck,unused
 
 	// Filters to be executed before/after request a file.
 	Filters Filters
@@ -353,7 +353,7 @@ type StaticFS struct {
 //
 // It is prohibited copying RequestCtx values. Create new values instead.
 type RequestCtx struct {
-	noCopy nocopy.NoCopy
+	noCopy nocopy.NoCopy // nolint:structcheck,unused
 
 	next     bool
 	skipView bool


### PR DESCRIPTION
This PR fixes just the minimal and default set of lint errors, e.g. only the ones found when running `golangci-lint run`

To increase quality we may want to add `golangci-lint run --enable-all` but that requires more cleanup work (quite a lot of it...) so let's start with this basic set. 

```
go test ./...
ok  	github.com/savsgio/atreugo/v10	4.138s
?   	github.com/savsgio/atreugo/v10/examples/basic	[no test files]
?   	github.com/savsgio/atreugo/v10/examples/jwt_auth	[no test files]
?   	github.com/savsgio/atreugo/v10/examples/middlewares_filters	[no test files]
?   	github.com/savsgio/atreugo/v10/examples/static_files	[no test files]
ok  	github.com/savsgio/atreugo/v10/middlewares	(cached)
```
