### PR TITLE
support configurable log output

### DIFF
--- a/atreugo.go
+++ b/atreugo.go
@@ -35,12 +35,16 @@ func New(cfg Config) *Atreugo {
 		cfg.LogLevel = logger.INFO
 	}
 
+	if cfg.LogOutput == nil {
+		cfg.LogOutput = os.Stderr
+	}
+
 	if cfg.GracefulShutdown && cfg.ReadTimeout <= 0 {
 		cfg.ReadTimeout = defaultReadTimeout
 	}
 
 	cfg.socketFileMode = 0666
-	log := logger.New(cfg.LogName, cfg.LogLevel, os.Stderr)
+	log := logger.New(cfg.LogName, cfg.LogLevel, cfg.LogOutput)
 
 	r := newRouter(log, cfg.ErrorView)
 

--- a/types.go
+++ b/types.go
@@ -1,6 +1,7 @@
 package atreugo
 
 import (
+	"io"
 	"net"
 	"os"
 	"time"
@@ -46,6 +47,9 @@ type Config struct { // nolint:maligned
 
 	// See levels in https://github.com/savsgio/go-logger#levels
 	LogLevel string
+
+	// Default: os.Stderr
+	LogOutput io.Writer
 
 	// Kind of network listener (default: tcp4)
 	// The network must be "tcp", "tcp4", "tcp6" or "unix".


### PR DESCRIPTION
This PR adds support for providing a custom `io.Writer` to redirect log output to any facility of the user's choice.