### PR TITLE
make server variable public

### DIFF
--- a/atreugo.go
+++ b/atreugo.go
@@ -265,3 +265,11 @@ func (s *Atreugo) NewVirtualHost(hostnames ...string) *Router {
 
 	return vHost
 }
+// Shutdown expose fasthttp server shutdown function
+func (s *Atreugo) Shutdown() error {
+     return  s.server.Shutdown()
+}
+// Server return fasthttp server instance
+func (s *Atreugo) Server() *fasthttp.Server {
+     return  s.server
+}

--- a/atreugo_test.go
+++ b/atreugo_test.go
@@ -435,6 +435,65 @@ func TestAtreugo_ServeConn(t *testing.T) {
 	}
 }
 
+func TestAtreugo_Shutdown(t *testing.T) {
+	cfg := Config{
+		LogLevel:    "fatal",
+		ReadTimeout: 1 * time.Second,
+	}
+	s := New(cfg)
+
+	c := &mock.Conn{ErrRead: errors.New("Read error")}
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- s.ServeConn(c)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	if err := s.Shutdown(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if err := <-errCh; err == nil {
+		t.Fatalf("Expected error: %v", err)
+	}
+
+	if s.server.Handler == nil {
+		t.Error("Atreugo.server.Handler is nil")
+	}
+}
+func TestAtreugo_Server(t *testing.T) {
+	cfg := Config{
+		LogLevel:    "fatal",
+		ReadTimeout: 1 * time.Second,
+	}
+	s := New(cfg)
+
+	c := &mock.Conn{ErrRead: errors.New("Read error")}
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- s.ServeConn(c)
+	}()
+	if s.Server() == nil {
+		t.Fatal("Unexpected error: server is nil")
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if err := s.Shutdown(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if err := <-errCh; err == nil {
+		t.Fatalf("Expected error: %v", err)
+	}
+
+	if s.server.Handler == nil {
+		t.Error("Atreugo.server.Handler is nil")
+	}
+}
+
 func TestAtreugo_Serve(t *testing.T) {
 	cfg := Config{LogLevel: "fatal"}
 	s := New(cfg)


### PR DESCRIPTION
The use case:
I have have a multiple instance of atreugo in single application.  They have kind of dependency between each other.
I like to shutdown both instances gracefully  using context with timeout in certain order. The only way to achieve this is to implement a custom graceful stop. To do that i need a direct access to fasthttp instance in  atreugo  structure or  expose fasthttp shutdown function 
