### PR TITLE
Adding UseFinal Middleware to Ensure Consistent HTTP Response Management

### DIFF
--- a/path.go
+++ b/path.go
@@ -38,6 +38,17 @@ func (p *Path) UseAfter(fns ...Middleware) *Path {
 	return p
 }
 
+// UseFinal registers the given middlewares to be executed in the order in which they are added,
+// after the view or group has been executed. These middlewares will always be executed,
+// even if a previous middleware or the view/group returned a response.
+func (p *Path) UseFinal(fns ...Middleware) *Path {
+	p.middlewares.Final = append(p.middlewares.Final, fns...)
+
+	p.router.handlePath(p)
+
+	return p
+}
+
 // SkipMiddlewares registers the middlewares that you want to skip only when executing the view.
 func (p *Path) SkipMiddlewares(fns ...Middleware) *Path {
 	p.middlewares.Skip = append(p.middlewares.Skip, fns...)

--- a/path.go
+++ b/path.go
@@ -41,7 +41,7 @@ func (p *Path) UseAfter(fns ...Middleware) *Path {
 // UseFinal registers the given middlewares to be executed in the order in which they are added,
 // after the view or group has been executed. These middlewares will always be executed,
 // even if a previous middleware or the view/group returned a response.
-func (p *Path) UseFinal(fns ...Middleware) *Path {
+func (p *Path) UseFinal(fns ...FinalMiddleware) *Path {
 	p.middlewares.Final = append(p.middlewares.Final, fns...)
 
 	p.router.handlePath(p)

--- a/path_test.go
+++ b/path_test.go
@@ -97,8 +97,13 @@ func TestPath_UseAfter(t *testing.T) {
 }
 
 func TestPath_UseFinal(t *testing.T) {
+	var finalMiddlewareFns = []FinalMiddleware{
+		func(ctx *RequestCtx) {},
+		func(ctx *RequestCtx) {},
+	}
+
 	p := newTestPath()
-	p.UseFinal(middlewareFns...)
+	p.UseFinal(finalMiddlewareFns...)
 
 	if len(p.middlewares.Final) != len(middlewareFns) {
 		t.Errorf("Final middlewares are not registered")

--- a/path_test.go
+++ b/path_test.go
@@ -97,9 +97,11 @@ func TestPath_UseAfter(t *testing.T) {
 }
 
 func TestPath_UseFinal(t *testing.T) {
-	var finalMiddlewareFns = []FinalMiddleware{
-		func(ctx *RequestCtx) {},
-		func(ctx *RequestCtx) {},
+	finalMiddlewareFns := []FinalMiddleware{
+		func(ctx *RequestCtx) {
+		},
+		func(ctx *RequestCtx) {
+		},
 	}
 
 	p := newTestPath()

--- a/path_test.go
+++ b/path_test.go
@@ -96,6 +96,17 @@ func TestPath_UseAfter(t *testing.T) {
 	assertHandle(t, p)
 }
 
+func TestPath_UseFinal(t *testing.T) {
+	p := newTestPath()
+	p.UseFinal(middlewareFns...)
+
+	if len(p.middlewares.Final) != len(middlewareFns) {
+		t.Errorf("Final middlewares are not registered")
+	}
+
+	assertHandle(t, p)
+}
+
 func TestPath_SkipMiddlewares(t *testing.T) {
 	p := newTestPath()
 	p.SkipMiddlewares(middlewareFns...)

--- a/router.go
+++ b/router.go
@@ -116,6 +116,7 @@ func (r *Router) handler(fn View, middle Middlewares) fasthttp.RequestHandler {
 		for i := 0; i < chainLen; i++ {
 			if err := chain[i](actx); err != nil {
 				r.handleMiddlewareError(actx, err)
+
 				break
 			} else if !actx.next {
 				break

--- a/router.go
+++ b/router.go
@@ -81,7 +81,6 @@ func (r *Router) buildMiddlewares(m Middlewares) Middlewares {
 
 	m2.Before = appendMiddlewares(m2.Before[:0], m2.Before, m2.Skip...)
 	m2.After = appendMiddlewares(m2.After[:0], m2.After, m2.Skip...)
-	m2.Final = appendMiddlewares(m2.Final[:0], m2.Final, m2.Skip...)
 
 	return m2
 }
@@ -126,10 +125,7 @@ func (r *Router) handler(fn View, middle Middlewares) fasthttp.RequestHandler {
 		}
 
 		for _, final := range middle.Final {
-			if err := final(actx); err != nil {
-				r.handleMiddlewareError(actx, err)
-				break
-			}
+			final(actx)
 		}
 
 		ReleaseRequestCtx(actx)
@@ -237,7 +233,7 @@ func (r *Router) UseAfter(fns ...Middleware) *Router {
 // UseFinal registers the given middlewares to be executed in the order in which they are added,
 // after the view or group has been executed. These middlewares will always be executed,
 // even if a previous middleware or the view/group returned a response.
-func (r *Router) UseFinal(fns ...Middleware) *Router {
+func (r *Router) UseFinal(fns ...FinalMiddleware) *Router {
 	r.middlewares.Final = append(r.middlewares.Final, fns...)
 
 	return r

--- a/router_test.go
+++ b/router_test.go
@@ -424,9 +424,10 @@ func TestRouter_handler(t *testing.T) { //nolint:funlen,maintidx
 			return ctx.Next()
 		},
 	}
-	final := []FinalMiddleware{func(ctx *RequestCtx) {
-		handlerCounter.finalMiddlewares++
-	},
+	final := []FinalMiddleware{
+		func(ctx *RequestCtx) {
+			handlerCounter.finalMiddlewares++
+		},
 	}
 
 	middlewares := Middlewares{

--- a/types.go
+++ b/types.go
@@ -546,12 +546,15 @@ type PanicView func(*RequestCtx, interface{})
 // Middleware must process all incoming requests before/after defined views.
 type Middleware View
 
+// FinalMiddleware must process all incoming requests after the other middlewares/view.
+type FinalMiddleware func(*RequestCtx)
+
 // Middlewares is a collection of middlewares with the order of execution and which to skip.
 type Middlewares struct {
 	Before []Middleware
 	After  []Middleware
 	Skip   []Middleware
-	Final  []Middleware
+	Final  []FinalMiddleware
 }
 
 // PathRewriteFunc must return new request path based on arbitrary ctx

--- a/types.go
+++ b/types.go
@@ -551,6 +551,7 @@ type Middlewares struct {
 	Before []Middleware
 	After  []Middleware
 	Skip   []Middleware
+	Final  []Middleware
 }
 
 // PathRewriteFunc must return new request path based on arbitrary ctx


### PR DESCRIPTION
We have a situation where the Before middleware is returning an HTTP response. 
Additionally, in the same service, we have an After middleware that we use to manage a metric of HTTP response status codes. 
The current design does not support this case because the middleware chain is interrupted since the Before middleware returned an HTTP response, and we could not call `ctx.next` in this case.

In our implementation, we initially assumed that the after middleware would always be called. 
For this case, and many others, we believe it is important to add middleware that will be called just before sending the HTTP response, without relying on what happened in the before, view, or after stages.

We decided not to use the existing middleware interface because it does not make sense for logic that runs at this stage to return an error since we did not want to change the `ctx.Response` based on these functions. 
These functions should have logic that is separate from the existing logic for handling the request.

To solve the issue of HTTP responses being returned by Before middleware, we propose defining a new middleware method called `UseFinal`. 
Any logic added to this middleware will be executed regardless of what happened in the before, view, or after stages, and will be called just before sending the HTTP response. 

This approach will allow us to properly manage HTTP response status codes in all scenarios, without relying on the behavior of other middleware in the chain. 
We believe this is a clean and effective solution that will improve the maintainability and scalability of our codebase.