### PR TITLE
align handling of graceful shutdown signals

### DIFF
--- a/atreugo_unix.go
+++ b/atreugo_unix.go
@@ -22,6 +22,9 @@ func (s *Atreugo) ServeGracefully(ln net.Listener) error {
 	}()
 
 	osSignals := make(chan os.Signal, 1)
+	if s.cfg.GracefulShutdown && len(s.cfg.GracefulShutdownSignals) == 0 {
+		s.cfg.GracefulShutdownSignals = append(s.cfg.GracefulShutdownSignals, defaultGracefulShutdownSignals...)
+	}
 	signal.Notify(osSignals, s.cfg.GracefulShutdownSignals...)
 
 	select {

--- a/atreugo_unix.go
+++ b/atreugo_unix.go
@@ -21,10 +21,11 @@ func (s *Atreugo) ServeGracefully(ln net.Listener) error {
 		listenErr <- s.Serve(ln)
 	}()
 
-	osSignals := make(chan os.Signal, 1)
 	if s.cfg.GracefulShutdown && len(s.cfg.GracefulShutdownSignals) == 0 {
 		s.cfg.GracefulShutdownSignals = append(s.cfg.GracefulShutdownSignals, defaultGracefulShutdownSignals...)
 	}
+
+	osSignals := make(chan os.Signal, 1)
 	signal.Notify(osSignals, s.cfg.GracefulShutdownSignals...)
 
 	select {

--- a/atreugo_unix_test.go
+++ b/atreugo_unix_test.go
@@ -101,6 +101,10 @@ func TestAtreugo_ServeGracefully(t *testing.T) { // nolint:funlen
 				t.Errorf("Config.GracefulShutdown = %v, want %v", cfg.GracefulShutdown, true)
 			}
 
+			if len(s.cfg.GracefulShutdownSignals) == 0 {
+				t.Errorf("Config.GracefulShutdownSignals is empty, want %v", defaultGracefulShutdownSignals)
+			}
+
 			lnAddr := ln.Addr().String()
 			if s.cfg.Addr != lnAddr {
 				t.Errorf("Atreugo.Config.Addr = %s, want %s", s.cfg.Addr, lnAddr)


### PR DESCRIPTION
Currently there is a discrepancy in the handling of graceful shutdown that occurs in the following scenario:

```go
s := atreugo.New(atreugo.Config{Name: "my-cool-server"})
s.ServeGracefully(listener)
```

In this scenario, the GracefulShutdownSignals slice remains nil, which leads to the the server terminating on *any* signal, including signals that should be ignored like SIGURG.

This MR fixes this behavior and aligns it with the behavior of the `New` method, if the server is requested to support graceful shutdown.
